### PR TITLE
Fixed answers being too easy when there's markers

### DIFF
--- a/src/com/pikamander2/japanesequiz/Question.java
+++ b/src/com/pikamander2/japanesequiz/Question.java
@@ -7,11 +7,17 @@ import java.util.Random;
 
 public class Question
 {
+	public final int MARKER_START = 46;
+
 	private Random random = new Random();
+
+	private int currentAnswer;
 
 	private ArrayList<String[]> listToUse;
 
 	private int listId;
+
+	private ArrayList<String> answerHistory = new ArrayList<String>();
 
 	private static String[][] tempHiraganaList = {{"あ", "a"},{"い", "i"},{"う", "u"},{"え", "e"},{"お", "o"},
 		{"か", "ka"},{"き", "ki"},{"く", "ku"},{"け", "ke"},{"こ", "ko"},
@@ -59,14 +65,12 @@ public class Question
 		setList(tempListId);
 	}
 
-	public void shuffleQuestions()
+	public void prepareList()
 	{
 		if (listId == 4)
 		{
 			setList(4);
 		}
-
-		Collections.shuffle(listToUse);
 	}
 
 	public void setList(int tempListId)
@@ -100,6 +104,14 @@ public class Question
 		}
 	}
 
+	public void setCurrentAnswer(int answer){
+		this.currentAnswer = answer;
+	}
+
+	public String getCurrentAnswer(boolean romajiFirst){
+		return listToUse.get(currentAnswer)[romajiFirst ? 0 : 1];
+	}
+
 	public String getQuestion(int charID, boolean romajiFirst)
 	{
 		if (romajiFirst)
@@ -111,5 +123,31 @@ public class Question
 		{
 			return listToUse.get(charID)[0];
 		}
+	}
+
+	public String getRandomAnswer(boolean romajiFirst){
+		String candidateAnswer = "";
+		int candidateNumber;
+
+		do{
+			candidateNumber = this.random.nextInt(listToUse.size());
+
+			if(currentAnswer >= MARKER_START && candidateNumber < MARKER_START)
+				candidateNumber = (candidateNumber % (listToUse.size() - MARKER_START) + MARKER_START);
+			candidateAnswer = getAnswer(candidateNumber, romajiFirst);
+		} while(answerHistory.contains(candidateAnswer));
+
+		answerHistory.add(candidateAnswer);
+
+		return candidateAnswer;
+	}
+
+	public void clearHistory(boolean romajiFirst){
+		this.answerHistory = new ArrayList<String>();
+		this.answerHistory.add(listToUse.get(currentAnswer)[romajiFirst ? 0 : 1]);
+	}
+
+	public ArrayList<String[]> getUsedList(){
+		return listToUse;
 	}
 }

--- a/src/com/pikamander2/japanesequiz/QuestionAdapter.java
+++ b/src/com/pikamander2/japanesequiz/QuestionAdapter.java
@@ -1,6 +1,7 @@
 package com.pikamander2.japanesequiz;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Random;
 
 import com.pikamander2.japanesequiz.R;
@@ -31,10 +32,12 @@ public class QuestionAdapter extends BaseAdapter
 
     public void changeAnswers(boolean romajiFirst)
     {
-    	buttons.get(0).setText(question.getAnswer(0, romajiFirst));
-    	buttons.get(1).setText(question.getAnswer(1, romajiFirst));
-    	buttons.get(2).setText(question.getAnswer(2, romajiFirst));
-    	buttons.get(3).setText(question.getAnswer(3, romajiFirst));
+		buttons.get(0).setText(question.getRandomAnswer(romajiFirst));
+		buttons.get(1).setText(question.getRandomAnswer(romajiFirst));
+		buttons.get(2).setText(question.getRandomAnswer(romajiFirst));
+		buttons.get(3).setText(question.getRandomAnswer(romajiFirst));
+
+		buttons.get(random.nextInt(4)).setText(question.getCurrentAnswer(romajiFirst));
     }
 
     public void makeButtons()
@@ -45,9 +48,10 @@ public class QuestionAdapter extends BaseAdapter
             newButton.setOnClickListener(mContext.answerOnClick);
             buttons.add(newButton);
             newButton.setTextSize(TypedValue.COMPLEX_UNIT_SP,mContext.getResources().getDimension(R.dimen.button_font_size));
-            newButton.setText(question.getAnswer(i, true));
             newButton.setTextColor(Color.rgb(255,255,255));
     	}
+
+			changeAnswers(true);
     }
 
     public int getCount()

--- a/src/com/pikamander2/japanesequiz/QuizActivity.java
+++ b/src/com/pikamander2/japanesequiz/QuizActivity.java
@@ -140,11 +140,15 @@ public class QuizActivity extends Activity
 
 	public void switchQuestion()
 	{
-		question.shuffleQuestions();
-		int randNum = random.nextInt(4);
+		question.prepareList();
+		int randNum = random.nextInt(question.getUsedList().size());
 
 		currentQuestion = question.getQuestion(randNum, romajiFirst);
 		currentAnswer = question.getAnswer(randNum, romajiFirst);
+
+		question.setCurrentAnswer(randNum);
+		question.clearHistory(romajiFirst);
+
 		textViewRomaji.setText(currentQuestion);
 	}
 


### PR DESCRIPTION
Slightly bigger PR this time.

An attempt to fix the issue #4 

If the question contains a marker, it will only pick possible answers from the pool of characters with markers, be they dakuten or handakuten.
